### PR TITLE
Fix deprecation warnings with Python-Markdown 3.x

### DIFF
--- a/markdown_jinja.py
+++ b/markdown_jinja.py
@@ -25,10 +25,12 @@ class JinjaPreprocessor(Preprocessor):
     def __init__(self, md, config):
         super(JinjaPreprocessor, self).__init__(md)
         if config['fs_loader_dir']:
-            self.environment = Environment(loader=FileSystemLoader(config['fs_loader_dir']))
+            self.environment = Environment(
+                loader=FileSystemLoader(config['fs_loader_dir']))
         else:
             self.environment = Environment()
-        self.context = json.load(open(config['context_file'])) if config['context_file'] else {}
+        self.context = json.load(
+            open(config['context_file'])) if config['context_file'] else {}
 
     def run(self, lines):
         text = '\n'.join(lines)
@@ -37,5 +39,5 @@ class JinjaPreprocessor(Preprocessor):
         return new_text.split('\n')
 
 
-def makeExtension(*args,**kwargs):
+def makeExtension(*args, **kwargs):
     return MarkdownJinja(kwargs)

--- a/markdown_jinja.py
+++ b/markdown_jinja.py
@@ -16,10 +16,9 @@ class MarkdownJinja(Extension):
         for key, value in configs.items():
             self.setConfig(key, value)
 
-    def extendMarkdown(self, md, md_globals):
-        md.preprocessors.add(
-            'jinja', JinjaPreprocessor(md, self.getConfigs()), '_begin'
-        )
+    def extendMarkdown(self, md):
+        jinja = JinjaPreprocessor(md, self.getConfigs())
+        md.preprocessors.register(jinja, 'jinja', 25)
 
 
 class JinjaPreprocessor(Preprocessor):

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(
     'Topic :: Text Processing :: Filters',
     'Topic :: Text Processing :: Markup :: HTML'
   ],
-  install_requires = ['Markdown>=2.6', 'Jinja2>=2.10']
+  install_requires=['Markdown>=3.0', 'Jinja2>=2.10']
 )

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,35 @@
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
-  name = 'markdown-jinja',
-  version = '0.1.0',
-  py_modules = ['markdown_jinja'],
-  description = 'Python Markdown extension which adds Jinja2 support',
-  author = 'Józef Sokołowski',
-  author_email = 'pypi@qzb.me',
-  url = 'https://github.com/qzb/markdown-jinja/',
-  download_url = 'https://github.com/qzb/markdown-jinja/archive/v0.1.0.tar.gz',
-  classifiers = [
-    'Development Status :: 3 - Alpha',
-    'License :: OSI Approved :: MIT License',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
-    'Intended Audience :: Developers',
-    'Topic :: Communications :: Email :: Filters',
-    'Topic :: Internet :: WWW/HTTP :: Dynamic Content :: CGI Tools/Libraries',
-    'Topic :: Internet :: WWW/HTTP :: Site Management',
-    'Topic :: Software Development :: Documentation',
-    'Topic :: Software Development :: Libraries :: Python Modules',
-    'Topic :: Text Processing :: Filters',
-    'Topic :: Text Processing :: Markup :: HTML'
-  ],
+    name='markdown-jinja',
+    version='0.1.0',
+    py_modules=['markdown_jinja'],
+    description='Python Markdown extension which adds Jinja2 support',
+    author='Józef Sokołowski',
+    author_email='pypi@qzb.me',
+    url='https://github.com/qzb/markdown-jinja/',
+    download_url='https://github.com/qzb/markdown-jinja/archive/v0.1.0.tar.gz',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Intended Audience :: Developers',
+        'Topic :: Communications :: Email :: Filters',
+        'Topic :: Internet :: WWW/HTTP :: Dynamic Content :: CGI Tools/Libraries',
+        'Topic :: Internet :: WWW/HTTP :: Site Management',
+        'Topic :: Software Development :: Documentation',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Text Processing :: Filters',
+        'Topic :: Text Processing :: Markup :: HTML'
+    ],
   install_requires=['Markdown>=3.0', 'Jinja2>=2.10']
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='markdown-jinja',
-    version='0.1.0',
+    version='1.0.0',
     py_modules=['markdown_jinja'],
     description='Python Markdown extension which adds Jinja2 support',
     author='Józef Sokołowski',


### PR DESCRIPTION
Fix deprecation warnings with Python-Markdown 3.x

- https://python-markdown.github.io/change_log/release-3.0/#md_globals-keyword-deprecated-from-extension-api
- https://python-markdown.github.io/change_log/release-3.0/#homegrown-ordereddict-has-been-replaced-with-a-purpose-built-registry

The priority number was arbitrarily chosen.